### PR TITLE
Add playbooks for building docker images and installing clients

### DIFF
--- a/build_dockers.yml
+++ b/build_dockers.yml
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#      $ cp vars/settings.yml.template vars/settings.yml
+#
+#      Fill out vars/settings.yml.
+#
+#      $ ansible-playbook -i TARGET-HOST build_dockers.yml [OPTIONS]...
+#
+# Required parameters should be specified in vars/settings.yml or --extra-vars
+# ansible command line parameter. For details, see vars/settings.yml.template.
+#
+# Examples:
+# To run on your localhost (Note comma is needed after localhost):
+# $ ansible-playbook -i localhost, build_dockers.yml -c local
+#
+# To run this on a remote host, say build01, as root:
+# $ ansible-playbook -i build01, build_dockers.yml  \
+#       --become --become-user root --ask-become-pass
+- hosts: all
+  vars_files:
+    - vars/settings.yml
+  tasks:
+    - assert:
+        that: ansible_version.major >= 2
+        msg: "Only supports ansible version 2.x."
+
+    - assert:
+        that: dist_path_or_url is defined
+        msg: >
+          'dist_path_or_url' should point to a URL of a Spark distribution
+          package.  See vars/settings.yml.template for details.
+
+    - assert:
+        that: docker_registry is defined
+        msg: >
+          'docker_registry' should specify docker registry host and port.
+          See vars/settings.yml.template for details.
+
+    - name: Create a temporary workdir
+      command: mktemp -d /tmp/build-images-workdir-XXXXX
+      register: _workdir_register
+
+    - name: Set workdir as fact
+      set_fact: _workdir={{ _workdir_register.stdout }}
+
+    - block:
+        # NOTE. The unarchive module is broken with macOS BSD tar. Install
+        # GNU tar and make sure your path points it for the tar command.
+        # See https://github.com/ansible/ansible-modules-core/issues/3952.
+        - name: Unarchive dist
+          unarchive:
+            src: "{{ dist_path_or_url }}"
+            dest: "{{ _workdir }}"
+            copy: no
+
+        - name: Locate the unarchived
+          command: ls -1 "{{ _workdir }}/"
+          register: _ls_register
+
+        - name: Set package subdir as fact
+          set_fact: _package_subdir={{ _ls_register.stdout }}
+
+        - name: Build and push images
+          shell: >
+            docker build -t {{ docker_registry }}/spark-{{ item }}:latest  \
+                -f dockerfiles/{{ item }}/Dockerfile .  &&
+            docker push {{ docker_registry }}/spark-{{ item }}:latest
+          args:
+            chdir: "{{ _workdir }}/{{ _package_subdir }}"
+          with_items:
+            - driver
+            - executor
+
+    - always:
+        - name: Remove workdir
+          file: 
+            path: "{{ _workdir }}"
+            state: absent

--- a/install_clients.yml
+++ b/install_clients.yml
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#      $ cp vars/settings.yml.template vars/settings.yml
+#
+#      Fill out vars/settings.yml.
+#
+#      $ ansible-playbook -i INVENTORY install_clients.yml [OPTIONS]...
+#
+# Required parameters should be specified in vars/settings.yml or --extra-vars
+# ansible command line parameter. For details, see vars/settings.yml.template.
+#
+# Examples:
+# To run on your localhost as root:
+# $ ansible-playbook -i localhost, install_clients.yml -c local  \
+#       --become --become-user root --ask-become-pass
+#
+# To run this on remote hosts, say build01-03, as root:
+# $ ansible-playbook -i build01,build02,build03, install_clients.yml  \
+#       --become --become-user root
+- hosts: all
+  vars_files:
+    - vars/settings.yml
+  tasks:
+    - assert:
+        that: ansible_version.major >= 2
+        msg: "Only supports ansible version 2.x."
+
+    - assert:
+        that: dist_path_or_url is defined
+        msg: >
+          'dist_path_or_url' should point to a URL of a Spark distribution
+          package.  See vars/settings.yml.template for details.
+
+    - assert:
+        that: k8s_api_server_url is defined
+        msg: >
+          'k8s_api_server_url' should point to a URL of your kubernetes
+          API server.  See vars/settings.yml.template for details.
+
+    - assert:
+        that: docker_registry is defined
+        msg: >
+          'docker_registry' should specify docker registry host and port.
+          See vars/settings.yml.template for details.
+
+    - assert:
+        that: install_dir is defined
+        msg: >
+          'install_dir' should specify a dir under which the unpacked
+          package should be installed. e.g. /usr/local/ or /opt/.
+          See vars/settings.yml.template for details.
+
+    - name: Create a temporary workdir
+      command: mktemp -d /tmp/build-images-workdir-XXXXX
+      register: _workdir_register
+
+    - name: Set workdir as fact
+      set_fact: _workdir={{ _workdir_register.stdout }}
+
+    - block:
+        # NOTE. The unarchive module is broken with macOS BSD tar. Install
+        # GNU tar and make sure your path points it for the tar command.
+        # See https://github.com/ansible/ansible-modules-core/issues/3952.
+        - name: Unarchive dist
+          unarchive:
+            src: "{{ dist_path_or_url }}"
+            dest: "{{ _workdir }}"
+            copy: no
+
+        - name: Locate the unarchived
+          command: ls -1 "{{ _workdir }}/"
+          register: _ls_register
+
+        - name: Set package subdir as fact
+          set_fact: _package_subdir={{ _ls_register.stdout }}
+
+        - name: Set full target path as fact
+          set_fact: _package_dir="{{ install_dir }}/{{ _package_subdir}}"
+
+        - name: Stat the target dir
+          stat:
+            path: "{{ _package_dir }}"
+          register: _stat_register
+
+        - name: Rename the target dir if it already exists
+          shell: >
+            export DATETIME=`date "+%Y%m%d%H%M%S"`;
+            mv {{ _package_dir }} {{ _package_dir }}.backup-${DATETIME}
+          when: _stat_register.stat.exists
+
+        - name: Move package to {{ install_dir }}
+          command: >
+            mv {{ _workdir }}/{{ _package_subdir }} {{ install_dir }}
+
+        - name: Create symlink {{ install_dir }}/spark-on-k8s
+          file:
+            src: "{{ _package_dir }}"
+            dest: "{{ install_dir }}/spark-on-k8s"
+            state: link
+
+        - name: Fill out Spark default config files
+          template:
+            src: "templates/{{ item }}.j2"
+            dest: "{{ _package_dir }}/conf/{{ item }}"
+            backup: yes
+          with_items:
+            - spark-defaults.conf
+
+    - always:
+        - name: Remove workdir
+          file: 
+            path: "{{ _workdir }}"
+            state: absent

--- a/templates/spark-defaults.conf.j2
+++ b/templates/spark-defaults.conf.j2
@@ -1,0 +1,21 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#}
+spark.submit.deployMode cluster
+spark.master k8s://{{ k8s_api_server_url }}
+spark.kubernetes.driver.docker.image {{ docker_registry }}/spark-driver:latest
+spark.kubernetes.executor.docker.image {{ docker_registry }}/spark-executor:latest
+spark.kubernetes.namespace default

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copy this file to settings.yml and specify parameters below.
+
+# Required. Uncomment and specify a path or URL of a Spark distribution package
+# that has k8s support. A package can be built by dev/make-distribution.sh in
+# the Spark code.  For example, the following command will produce something
+# like spark-2.2.0-snapshot-bin-k8s-20170117.tgz.
+#
+#    $ ./dev/make-distribution.sh --name k8s-20170117 --tgz -Phadoop-2.6  \
+#        -Pkubernetes
+#
+# Then, you can upload it to a web server and specify the URL here.
+# Alternatively, if the package is on your target host, you can specify the
+# local path. Supported file formats are .tgz, and .zip.
+#
+# Examples:
+# dist_path_or_url: http://myhost/spark-2.2.0-snapshot-bin-k8s-20170117.tgz
+# dist_path_or_url: /tmp/spark-2.2.0-snapshot-bin-k8s-20170117.tgz
+#
+#dist_path_or_url: PATH or URL
+
+# Required. Uncomment and specify hostname and port of a docker registry that
+# images can be pushed to.  e.g. host1:5000.
+#
+# Examples:
+# docker_registry: myhost:5000
+#
+#docker_registry: HOST:PORT
+
+# Required. Uncomment and specify the URL of the API server of your kubernetes
+# cluster.
+#
+# Exampels:
+# k8s_api_server_url: https://192.168.6.151:6443
+#
+#k8s_api_server_url: URL
+
+# Required. Modify the default value below if necessary.  This is the path of
+# the dir under which the Spark client package will be installed.
+#
+install_dir: /opt/


### PR DESCRIPTION
@erikerlandson @ash211 @ssuchter 

Adds two playbooks:
- build_dockers.yml builds docker images from a specified distribution package
- install_clients.yml installs a package on hosts so people can submit spark jobs there

Common parameters are put into vars/settings.yml, which can be copied from vars/settings.yml.template and filled out.

I understand I have push privilege for apache-spark-on-k8s/ansible. Still sending a pull request so the change can be reviewed.