### PR TITLE
Allow override of docker tag

### DIFF
--- a/build_dockers.yml
+++ b/build_dockers.yml
@@ -50,6 +50,12 @@
           'docker_registry' should specify docker registry host and port.
           See vars/settings.yml.template for details.
 
+    - assert:
+        that: docker_tag is defined
+        msg: >
+          'docker_tag' should specify docker tag string.
+          See vars/settings.yml.template for details.
+
     - name: Create a temporary workdir
       command: mktemp -d /tmp/build-images-workdir-XXXXX
       register: _workdir_register
@@ -76,9 +82,10 @@
 
         - name: Build and push images
           shell: >
-            docker build -t {{ docker_registry }}/spark-{{ item }}:latest  \
+            docker build  \
+                -t {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}  \
                 -f dockerfiles/{{ item }}/Dockerfile .  &&
-            docker push {{ docker_registry }}/spark-{{ item }}:latest
+            docker push {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}
           args:
             chdir: "{{ _workdir }}/{{ _package_subdir }}"
           with_items:

--- a/install_clients.yml
+++ b/install_clients.yml
@@ -58,6 +58,12 @@
           See vars/settings.yml.template for details.
 
     - assert:
+        that: docker_tag is defined
+        msg: >
+          'docker_tag' should specify docker tag string.
+          See vars/settings.yml.template for details.
+
+    - assert:
         that: install_dir is defined
         msg: >
           'install_dir' should specify a dir under which the unpacked

--- a/templates/spark-defaults.conf.j2
+++ b/templates/spark-defaults.conf.j2
@@ -16,6 +16,6 @@
 #}
 spark.submit.deployMode cluster
 spark.master k8s://{{ k8s_api_server_url }}
-spark.kubernetes.driver.docker.image {{ docker_registry }}/spark-driver:latest
-spark.kubernetes.executor.docker.image {{ docker_registry }}/spark-executor:latest
+spark.kubernetes.driver.docker.image {{ docker_registry }}/spark-driver:{{ docker_tag }}
+spark.kubernetes.executor.docker.image {{ docker_registry }}/spark-executor:{{ docker_tag }}
 spark.kubernetes.namespace default

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -41,6 +41,11 @@
 #
 #docker_registry: HOST:PORT
 
+# Required. Modify the default value below if necessary.  This is the tag
+# associated with the docker images that we'll use.
+#
+docker_tag: latest
+
 # Required. Uncomment and specify the URL of the API server of your kubernetes
 # cluster.
 #


### PR DESCRIPTION
Update the existing `build_dockers.yml` and `install_clients.yml` to support overriding docker image tags, defaulting to the current `latest` tag.