### PR TITLE
Added support for building dev dockers from base spark kube docker im…

### DIFF
--- a/build_dev_dockers.yml
+++ b/build_dev_dockers.yml
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#      $ cp vars/settings.yml.template vars/settings.yml
+#
+#      Fill out vars/settings.yml.
+#
+#      $ ansible-playbook -i TARGET-HOST build_dockers.yml [OPTIONS]...
+#
+# Required parameters should be specified in vars/settings.yml or --extra-vars
+# ansible command line parameter. For details, see vars/settings.yml.template.
+#
+# Examples:
+# To run on your localhost (Note comma is needed after localhost):
+# $ ansible-playbook -i localhost, build_dockers.yml -c local
+#
+# To run this on a remote host, say build01, as root:
+# $ ansible-playbook -i build01, build_dockers.yml  \
+#       --become --become-user root --ask-become-pass
+- hosts: all
+  vars_files:
+    - vars/settings.yml
+  tasks:
+    - assert:
+        that: ansible_version.major >= 2
+        msg: "Only supports ansible version 2.x."
+
+    - assert:
+        that: spark_kubernetes_jar_path is defined
+        msg: >
+          'spark_kubernetes_jar_path' should point to a path of a Spark kubernetes
+          jar.  See vars/settings.yml.template for details.
+
+    - assert:
+        that: docker_registry is defined
+        msg: >
+          'docker_registry' should specify docker registry host and port.
+          See vars/settings.yml.template for details.
+
+    - assert:
+        that: docker_base_image is defined
+        msg: >
+          'docker_base_image' should specify the base image to be used to create docker images.
+          See vars/settings.yml.template for details.
+
+    - assert:
+        that: docker_tag is defined
+        msg: >
+          'docker_tag' should specify docker tag string.
+          See vars/settings.yml.template for details.
+
+    - name: Create a temporary workdir
+      command: mktemp -d /tmp/build-images-workdir-XXXXX
+      register: _workdir_register
+
+    - name: Set workdir as fact
+      set_fact: _workdir="{{ _workdir_register.stdout }}"
+
+    - name: Creates the jar directory in workspace
+      file: path="{{ _workdir }}/jars" state=directory
+
+    - name: Copy the jar file to workspace jars directory
+      copy: src="{{ spark_kubernetes_jar_path }}" dest="{{ _workdir }}/jars" remote_src=True
+
+    - name : Generate Dockerfile content
+      set_fact: dockerfile_content="FROM {{ docker_base_image }}\nCOPY jars /opt/spark/jars\n"
+
+    # Create a blank file
+    - name: Create an empty Dockerfile
+      file: path="{{ _workdir }}/Dockerfile" state=touch
+
+    - name: Write to Dockerfile
+      copy: content="{{ dockerfile_content }}" dest="{{ _workdir }}/Dockerfile"
+
+    - block:
+        # NOTE. The unarchive module is broken with macOS BSD tar. Install
+        # GNU tar and make sure your path points it for the tar command.
+        # See https://github.com/ansible/ansible-modules-core/issues/3952.
+        - name: Build and push images
+          shell: >
+            docker build  \
+                -t {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}  \
+                -f Dockerfile .  &&
+            docker push {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}
+          args:
+            chdir: "{{ _workdir }}"
+          with_items:
+            - driver
+            - executor
+
+    - always:
+        - name: Remove workdir
+          file:
+            path: "{{ _workdir }}"
+            state: absent

--- a/build_dev_dockers.yml
+++ b/build_dev_dockers.yml
@@ -25,10 +25,10 @@
 #
 # Examples:
 # To run on your localhost (Note comma is needed after localhost):
-# $ ansible-playbook -i localhost, build_dockers.yml -c local
+# $ ansible-playbook -i localhost, build_dev_dockers.yml -c local
 #
 # To run this on a remote host, say build01, as root:
-# $ ansible-playbook -i build01, build_dockers.yml  \
+# $ ansible-playbook -i build01, build_dev_dockers.yml  \
 #       --become --become-user root --ask-become-pass
 - hosts: all
   vars_files:
@@ -51,15 +51,15 @@
           See vars/settings.yml.template for details.
 
     - assert:
-        that: docker_base_image is defined
+        that: dev_docker_base_image is defined
         msg: >
-          'docker_base_image' should specify the base image to be used to create docker images.
+          'dev_docker_base_image' should specify the base image to be used to create docker images.
           See vars/settings.yml.template for details.
 
     - assert:
-        that: docker_tag is defined
+        that: dev_docker_tag is defined
         msg: >
-          'docker_tag' should specify docker tag string.
+          'dev_docker_tag' should specify docker tag string.
           See vars/settings.yml.template for details.
 
     - name: Create a temporary workdir
@@ -76,7 +76,7 @@
       copy: src="{{ spark_kubernetes_jar_path }}" dest="{{ _workdir }}/jars" remote_src=True
 
     - name : Generate Dockerfile content
-      set_fact: dockerfile_content="FROM {{ docker_base_image }}\nCOPY jars /opt/spark/jars\n"
+      set_fact: dockerfile_content="FROM {{ dev_docker_base_image }}\nCOPY jars /opt/spark/jars\n"
 
     # Create a blank file
     - name: Create an empty Dockerfile
@@ -92,9 +92,9 @@
         - name: Build and push images
           shell: >
             docker build  \
-                -t {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}  \
+                -t {{ docker_registry }}/spark-{{ item }}:{{ dev_docker_tag }}  \
                 -f Dockerfile .  &&
-            docker push {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}
+            docker push {{ docker_registry }}/spark-{{ item }}:{{ dev_docker_tag }}
           args:
             chdir: "{{ _workdir }}"
           with_items:

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -58,3 +58,11 @@ docker_tag: latest
 # the dir under which the Spark client package will be installed.
 #
 install_dir: /opt/
+
+# Optional. Please set this only, if you are building developer dockers.
+# Represents the path to the spark kubernetes jar which needs to go into the
+# docker image.
+# spark_kubernetes_jar_path: /tmp/spark-kubernetes_2.11-2.1.0-k8s-0.1.0-SNAPSHOT.jar
+
+# Optional. Base image to be used to build dev driver and executor dockers.
+# docker_base_image: spark-kube:latest

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -65,4 +65,4 @@ install_dir: /opt/
 # spark_kubernetes_jar_path: /tmp/spark-kubernetes_2.11-2.1.0-k8s-0.1.0-SNAPSHOT.jar
 
 # Optional. Base image to be used to build dev driver and executor dockers.
-# docker_base_image: spark-kube:latest
+# dev_docker_base_image: spark-kube:latest

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -49,7 +49,7 @@ docker_tag: latest
 # Required. Uncomment and specify the URL of the API server of your kubernetes
 # cluster.
 #
-# Exampels:
+# Examples:
 # k8s_api_server_url: https://192.168.6.151:6443
 #
 #k8s_api_server_url: URL
@@ -59,10 +59,14 @@ docker_tag: latest
 #
 install_dir: /opt/
 
-# Optional. Please set this only, if you are building developer dockers.
+# Optional. Please set the following properties only if you are building developer dockers.
+
+# Represents the tag to be used by dev docker driver and executor images.
+# dev_docker_tag: dev_latest
+
 # Represents the path to the spark kubernetes jar which needs to go into the
 # docker image.
 # spark_kubernetes_jar_path: /tmp/spark-kubernetes_2.11-2.1.0-k8s-0.1.0-SNAPSHOT.jar
 
-# Optional. Base image to be used to build dev driver and executor dockers.
+# Base image to be used to build dev driver and executor dockers.
 # dev_docker_base_image: spark-kube:latest


### PR DESCRIPTION
This change allows creating dev dockers quickly since it copies only the spark kubernetes core jar into an existing spark kubernetes docker image. These dev dockers are meant to be used mostly by developers to speed up their dev workflows.