### PR TITLE
Build the spark-base image locally

### DIFF
--- a/build_dockers.yml
+++ b/build_dockers.yml
@@ -80,6 +80,14 @@
         - name: Set package subdir as fact
           set_fact: _package_subdir={{ _ls_register.stdout }}
 
+        - name: Build spark-base image locally
+          shell: >
+            docker build --no-cache  \
+                -t spark-base:latest  \
+                -f dockerfiles/spark-base/Dockerfile .
+          args:
+            chdir: "{{ _workdir }}/{{ _package_subdir }}"
+
         - name: Build and push images
           shell: >
             docker build --no-cache  \

--- a/build_dockers.yml
+++ b/build_dockers.yml
@@ -83,13 +83,15 @@
         - name: Build spark-base image locally
           shell: >
             docker build --no-cache  \
-                -t spark-base:latest  \
+                -t spark-base:{{ docker_tag }}  \
                 -f dockerfiles/spark-base/Dockerfile .
           args:
             chdir: "{{ _workdir }}/{{ _package_subdir }}"
 
         - name: Build and push images
           shell: >
+            sed -i 's/^FROM spark-base$/FROM spark-base:{{ docker_tag }}/'  \
+                dockerfiles/{{ item }}/Dockerfile &&
             docker build --no-cache  \
                 -t {{ docker_registry }}/spark-{{ item }}:{{ docker_tag }}  \
                 -f dockerfiles/{{ item }}/Dockerfile .  &&


### PR DESCRIPTION
So that other images can refer to it while being built.