### PR TITLE
Support extra env variables in custom docker images

### DIFF
--- a/build_custom_dockers.yml
+++ b/build_custom_dockers.yml
@@ -53,12 +53,6 @@
           'custom_docker_tag' should specify a docker tag string.
           See vars/settings.yml.template for details.
 
-    - assert:
-        that: custom_docker_extra_files is defined
-        msg: >
-          'custom_docker_extra_files' should be defined.
-          See vars/settings.yml.template for details.
-
     - name: Create a temporary workdir
       command: mktemp -d /tmp/build-images-workdir-XXXXX
       register: _workdir_register

--- a/templates/custom-docker/Dockerfile.j2
+++ b/templates/custom-docker/Dockerfile.j2
@@ -16,10 +16,14 @@
 #}
 FROM {{ docker_registry }}/spark-{{ container }}:{{ docker_tag }}
 
+{% if custom_docker_extra_files is defined %}
 {% for item in custom_docker_extra_files %}
 COPY tmp{{ item.source }} {{ item.target }}
 {% endfor %}
+{% endif %}
 
+{% if custom_docker_extra_envs is defined %}
 {% for item in custom_docker_extra_envs %}
 ENV {{ item.name }} {{ item.value }}
 {% endfor %}
+{% endif %}

--- a/templates/custom-docker/Dockerfile.j2
+++ b/templates/custom-docker/Dockerfile.j2
@@ -1,0 +1,25 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#}
+FROM {{ docker_registry }}/spark-{{ container }}:{{ docker_tag }}
+
+{% for item in custom_docker_extra_files %}
+COPY tmp{{ item.source }} {{ item.target }}
+{% endfor %}
+
+{% for item in custom_docker_extra_envs %}
+ENV {{ item.name }} {{ item.value }}
+{% endfor %}

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -66,11 +66,11 @@ install_dir: /opt/
 #
 #custom_docker_tag: custom_latest
 
-# List of extra files or directories to copy to the custom docker images.
-# Each item should have the source and target paths. The source path is a local
-# file or directory. The target path is a file or directory inside the docker.
-# The source file or directory will be copied to a subdir inside the work dir
-# and supplied to the docker COPY command. Optionally, file mode can be
+# Optional. List of extra files or directories to copy to the custom docker
+# images. Each item should have the source and target paths. The source path is
+# a local file or directory. The target path is a file or directory inside the
+# docker.  The source file or directory will be copied to a subdir inside the
+# work dir and supplied to the docker COPY command. Optionally, file mode can be
 # specified per file item. (Default is "0644")
 #
 # Examples:
@@ -80,11 +80,9 @@ install_dir: /opt/
 #   - source: /mydir/log4j.properties
 #     target: /opt/spark/conf/
 #     mode: "0444"
-#
-#custom_docker_extra_files:
 
-# List of extra environment variables to set in the custom docker instances.
-# Each item should have the name and value strings.
+# Optional. List of extra environment variables to set in the custom docker
+# instances. Each item should have the name and value strings.
 #
 # Examples:
 # custom_docker_extra_envs:
@@ -92,5 +90,3 @@ install_dir: /opt/
 #     value: value1
 #   - name: ENV2
 #     value: value2
-#
-#custom_docker_extra_envs:

--- a/vars/settings.yml.template
+++ b/vars/settings.yml.template
@@ -82,3 +82,15 @@ install_dir: /opt/
 #     mode: "0444"
 #
 #custom_docker_extra_files:
+
+# List of extra environment variables to set in the custom docker instances.
+# Each item should have the name and value strings.
+#
+# Examples:
+# custom_docker_extra_envs:
+#   - name: ENV1
+#     value: value1
+#   - name: ENV2
+#     value: value2
+#
+#custom_docker_extra_envs:


### PR DESCRIPTION
Allow environment variables to be specified in custom Docker images. The jinja2 template file was missing before. This PR also fixes that.